### PR TITLE
fix: Add disk cache and improve rate limit resilience

### DIFF
--- a/ClaudeMeter/ClaudeMeter/Services/ClaudeProvider.swift
+++ b/ClaudeMeter/ClaudeMeter/Services/ClaudeProvider.swift
@@ -142,11 +142,19 @@ class ClaudeProvider: UsageProvider {
             limits.append(UsageLimit(
                 name: name,
                 utilization: utilization,
-                resetTime: nil
+                resetTime: parseDate(extraUsage["resets_at"] as? String) ?? nextMonthStart()
             ))
         }
 
         return ProviderUsageResponse(limits: limits)
+    }
+
+    private func nextMonthStart() -> Date {
+        let cal = Calendar.current
+        let now = Date()
+        let comps = cal.dateComponents([.year, .month], from: now)
+        let startOfMonth = cal.date(from: comps)!
+        return cal.date(byAdding: .month, value: 1, to: startOfMonth)!
     }
 
     private func formatCredits(_ value: Double) -> String {

--- a/ClaudeMeter/ClaudeMeter/Services/UsageManager.swift
+++ b/ClaudeMeter/ClaudeMeter/Services/UsageManager.swift
@@ -16,6 +16,7 @@ class UsageManager: ObservableObject {
     private var refreshTimer: Timer?
     private var refreshTask: Task<Void, Never>?
     private let notificationManager = NotificationManager()
+    private let cache = UsageCache()
 
     // Notification thresholds per provider
     private var notifiedThresholds: [String: Set<Int>] = [:]
@@ -70,7 +71,17 @@ class UsageManager: ObservableObject {
     init() {
         // Initialize provider states
         for provider in providers {
-            providerStates[provider.id] = ProviderState(provider: provider)
+            var state = ProviderState(provider: provider)
+            // Restore cached data so we have something to show immediately
+            if let cached = cache.load(providerId: provider.id) {
+                state.usage = cached.usage
+                state.lastUpdated = cached.date
+            }
+            providerStates[provider.id] = state
+        }
+
+        if let cachedDate = cache.lastUpdated() {
+            lastUpdated = cachedDate
         }
 
         startRefreshTimer()
@@ -103,7 +114,7 @@ class UsageManager: ObservableObject {
             for provider in availableProviders {
                 group.addTask {
                     do {
-                        let response = try await self.fetchWithRetry(provider: provider, retriesRemaining: 3)
+                        let response = try await self.fetchWithRetry(provider: provider, retriesRemaining: 2)
                         return (provider.id, response, nil)
                     } catch {
                         return (provider.id, nil, error.localizedDescription)
@@ -117,6 +128,9 @@ class UsageManager: ObservableObject {
                         state.usage = response
                         state.lastUpdated = Date()
                         state.error = nil
+
+                        // Cache to disk
+                        cache.save(providerId: providerId, usage: response)
 
                         // Check notification thresholds
                         checkThresholds(
@@ -146,7 +160,9 @@ class UsageManager: ObservableObject {
             try? await Task.sleep(nanoseconds: 3_000_000_000)
             return try await fetchWithRetry(provider: provider, retriesRemaining: retriesRemaining - 1)
         } catch let providerError as ProviderError where providerError.isRetryable && retriesRemaining > 0 {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            // Exponential backoff for rate limits: 10s, 20s
+            let delay = UInt64(10_000_000_000) * UInt64(3 - retriesRemaining)
+            try? await Task.sleep(nanoseconds: delay)
             return try await fetchWithRetry(provider: provider, retriesRemaining: retriesRemaining - 1)
         }
     }
@@ -225,6 +241,56 @@ class UsageManager: ObservableObject {
     var error: String? {
         // Return first error from any provider
         providerStates.values.compactMap { $0.error }.first
+    }
+}
+
+// MARK: - Usage Cache
+
+/// Persists usage data to disk so it survives app restarts and rate limiting
+private class UsageCache {
+    private let cacheDir: URL = {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("AIMeter/Cache", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }()
+
+    struct CachedUsage: Codable {
+        let limits: [CachedLimit]
+        let date: Date
+
+        struct CachedLimit: Codable {
+            let name: String
+            let utilization: Double
+            let resetTime: Date?
+        }
+    }
+
+    func save(providerId: String, usage: ProviderUsageResponse) {
+        let cached = CachedUsage(
+            limits: usage.limits.map { CachedUsage.CachedLimit(name: $0.name, utilization: $0.utilization, resetTime: $0.resetTime) },
+            date: Date()
+        )
+        let file = cacheDir.appendingPathComponent("\(providerId).json")
+        try? JSONEncoder().encode(cached).write(to: file)
+    }
+
+    func load(providerId: String) -> (usage: ProviderUsageResponse, date: Date)? {
+        let file = cacheDir.appendingPathComponent("\(providerId).json")
+        guard let data = try? Data(contentsOf: file),
+              let cached = try? JSONDecoder().decode(CachedUsage.self, from: data) else {
+            return nil
+        }
+        // Only use cache if less than 1 hour old
+        guard Date().timeIntervalSince(cached.date) < 3600 else { return nil }
+
+        let limits = cached.limits.map { UsageLimit(name: $0.name, utilization: $0.utilization, resetTime: $0.resetTime) }
+        return (ProviderUsageResponse(limits: limits), cached.date)
+    }
+
+    func lastUpdated() -> Date? {
+        let files = (try? FileManager.default.contentsOfDirectory(at: cacheDir, includingPropertiesForKeys: [.contentModificationDateKey])) ?? []
+        return files.compactMap { try? $0.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate }.max()
     }
 }
 

--- a/ClaudeMeter/ClaudeMeter/Views/MenuBarView.swift
+++ b/ClaudeMeter/ClaudeMeter/Views/MenuBarView.swift
@@ -133,12 +133,7 @@ struct ProviderSection: View {
                 }
             }
 
-            if let error = state.error {
-                Text(error)
-                    .font(.caption2)
-                    .foregroundColor(.red)
-                    .padding(.vertical, 2)
-            } else if let usage = state.usage {
+            if let usage = state.usage, !usage.limits.isEmpty {
                 ForEach(usage.limits, id: \.name) { limit in
                     UsageRow(
                         title: limit.name,
@@ -147,6 +142,11 @@ struct ProviderSection: View {
                         accentColor: provider.accentColor
                     )
                 }
+            } else if let error = state.error {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundColor(.red)
+                    .padding(.vertical, 2)
             } else {
                 Text("Loading...")
                     .font(.caption)


### PR DESCRIPTION
## Summary
- Cache usage data to disk so it survives app restarts and persistent API rate limiting
- Prioritize showing cached usage data over error messages in the UI
- Infer monthly credit reset date (1st of next month) for credit-based plans
- Use exponential backoff for 429 retries to reduce API pressure

## Context
The Anthropic usage API aggressively rate limits requests (HTTP 429), sometimes persistently for extended periods. Previously, the app would show "Rate limited. Will retry shortly." with no usage data, especially after restarts when there was no in-memory cache.

## Test plan
- [ ] Kill and relaunch app while API is rate limited — should show cached data
- [ ] Verify cache is written to `~/Library/Application Support/AIMeter/Cache/`
- [ ] Verify stale cache (>1hr) is ignored and fresh data is fetched
- [ ] Verify monthly reset countdown shows correctly (e.g., "Resets in 26d")

🤖 Generated with [Claude Code](https://claude.com/claude-code)