### PR TITLE
fix: Show dollar spend for unlimited Claude plans

### DIFF
--- a/ClaudeMeter/ClaudeMeter/AIMeterApp.swift
+++ b/ClaudeMeter/ClaudeMeter/AIMeterApp.swift
@@ -139,13 +139,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 limit = usage.limits.first { $0.name.contains("Weekly") || $0.name.contains("7d") || $0.name.contains("Monthly") }
             }
 
-            let percent = Int(limit?.utilization ?? usage.maxUtilization)
-            let color: NSColor = percent >= 90 ? .systemRed
-                                : percent >= 70 ? .systemOrange
-                                : .systemGreen
+            let displayText: String
+            let color: NSColor
+            if let lim = limit, lim.isUnlimited, let cost = lim.dollarCost {
+                displayText = lim.displayValue
+                switch cost {
+                case ..<200: color = .systemGreen
+                case ..<1000: color = .systemOrange
+                case ..<2000: color = .systemRed
+                default: color = .labelColor
+                }
+            } else {
+                let percent = Int(limit?.utilization ?? usage.maxUtilization)
+                displayText = "\(percent)%"
+                color = percent >= 90 ? .systemRed
+                       : percent >= 70 ? .systemOrange
+                       : .systemGreen
+            }
 
             let percentStr = NSAttributedString(
-                string: "\(percent)%",
+                string: displayText,
                 attributes: [.foregroundColor: color, .font: font]
             )
             attributedString.append(percentStr)

--- a/ClaudeMeter/ClaudeMeter/Services/ClaudeProvider.swift
+++ b/ClaudeMeter/ClaudeMeter/Services/ClaudeProvider.swift
@@ -131,18 +131,25 @@ class ClaudeProvider: UsageProvider {
         if let extraUsage = json["extra_usage"] as? [String: Any],
            let isEnabled = extraUsage["is_enabled"] as? Bool, isEnabled {
             let utilization = extraUsage["utilization"] as? Double ?? 0
-            let usedCredits = extraUsage["used_credits"] as? Double
+            let usedCents = extraUsage["used_credits"] as? Double
             let monthlyLimit = extraUsage["monthly_limit"] as? Int
+            let isUnlimited = monthlyLimit == nil || monthlyLimit == 0
 
             var name = "Monthly"
-            if let used = usedCredits, let limit = monthlyLimit {
-                name = "Monthly (\(formatCredits(used))/\(formatCredits(Double(limit))))"
+            if isUnlimited {
+                if let cents = usedCents {
+                    name = "Monthly (\(formatDollars(cents / 100.0)) spent)"
+                }
+            } else if let cents = usedCents, let limit = monthlyLimit {
+                name = "Monthly (\(formatDollars(cents / 100.0))/\(formatDollars(Double(limit) / 100.0)))"
             }
 
             limits.append(UsageLimit(
                 name: name,
                 utilization: utilization,
-                resetTime: parseDate(extraUsage["resets_at"] as? String) ?? nextMonthStart()
+                resetTime: parseDate(extraUsage["resets_at"] as? String) ?? nextMonthStart(),
+                isUnlimited: isUnlimited,
+                creditsUsed: usedCents
             ))
         }
 
@@ -162,6 +169,13 @@ class ClaudeProvider: UsageProvider {
             return String(format: "%.1fk", value / 1000)
         }
         return String(format: "%.0f", value)
+    }
+
+    private func formatDollars(_ value: Double) -> String {
+        if value >= 1000 {
+            return String(format: "$%.1fk", value / 1000)
+        }
+        return String(format: "$%.0f", value)
     }
 
     private func parseDate(_ dateString: String?) -> Date? {

--- a/ClaudeMeter/ClaudeMeter/Services/UsageManager.swift
+++ b/ClaudeMeter/ClaudeMeter/Services/UsageManager.swift
@@ -263,12 +263,14 @@ private class UsageCache {
             let name: String
             let utilization: Double
             let resetTime: Date?
+            let isUnlimited: Bool?
+            let creditsUsed: Double?
         }
     }
 
     func save(providerId: String, usage: ProviderUsageResponse) {
         let cached = CachedUsage(
-            limits: usage.limits.map { CachedUsage.CachedLimit(name: $0.name, utilization: $0.utilization, resetTime: $0.resetTime) },
+            limits: usage.limits.map { CachedUsage.CachedLimit(name: $0.name, utilization: $0.utilization, resetTime: $0.resetTime, isUnlimited: $0.isUnlimited, creditsUsed: $0.creditsUsed) },
             date: Date()
         )
         let file = cacheDir.appendingPathComponent("\(providerId).json")
@@ -284,7 +286,7 @@ private class UsageCache {
         // Only use cache if less than 1 hour old
         guard Date().timeIntervalSince(cached.date) < 3600 else { return nil }
 
-        let limits = cached.limits.map { UsageLimit(name: $0.name, utilization: $0.utilization, resetTime: $0.resetTime) }
+        let limits = cached.limits.map { UsageLimit(name: $0.name, utilization: $0.utilization, resetTime: $0.resetTime, isUnlimited: $0.isUnlimited ?? false, creditsUsed: $0.creditsUsed) }
         return (ProviderUsageResponse(limits: limits), cached.date)
     }
 

--- a/ClaudeMeter/ClaudeMeter/Services/UsageProvider.swift
+++ b/ClaudeMeter/ClaudeMeter/Services/UsageProvider.swift
@@ -34,8 +34,32 @@ struct UsageLimit {
     let name: String
     let utilization: Double  // 0-100
     let resetTime: Date?
+    let isUnlimited: Bool
+    let creditsUsed: Double?
+
+    init(name: String, utilization: Double, resetTime: Date?, isUnlimited: Bool = false, creditsUsed: Double? = nil) {
+        self.name = name
+        self.utilization = utilization
+        self.resetTime = resetTime
+        self.isUnlimited = isUnlimited
+        self.creditsUsed = creditsUsed
+    }
+
+    /// Dollar cost for unlimited plans (used_credits is in cents USD)
+    var dollarCost: Double? {
+        guard isUnlimited, let credits = creditsUsed else { return nil }
+        return credits / 100.0
+    }
 
     var statusColor: Color {
+        if isUnlimited, let cost = dollarCost {
+            switch cost {
+            case ..<200: return .green
+            case ..<1000: return .orange
+            case ..<2000: return .red
+            default: return .primary  // black/white depending on theme
+            }
+        }
         switch utilization {
         case ..<70: return .green
         case 70..<90: return .yellow
@@ -44,11 +68,34 @@ struct UsageLimit {
     }
 
     var statusEmoji: String {
+        if isUnlimited, let cost = dollarCost {
+            switch cost {
+            case ..<200: return "🟢"
+            case ..<1000: return "🟡"
+            case ..<2000: return "🔴"
+            default: return "⚫"
+            }
+        }
         switch utilization {
         case ..<70: return "🟢"
         case 70..<90: return "🟡"
         default: return "🔴"
         }
+    }
+
+    /// Display string for the status bar and usage row
+    var displayValue: String {
+        if isUnlimited, let cost = dollarCost {
+            return formatDollars(cost)
+        }
+        return "\(Int(utilization))%"
+    }
+
+    private func formatDollars(_ value: Double) -> String {
+        if value >= 1000 {
+            return String(format: "$%.1fk", value / 1000)
+        }
+        return String(format: "$%.0f", value)
     }
 }
 

--- a/ClaudeMeter/ClaudeMeter/Views/MenuBarView.swift
+++ b/ClaudeMeter/ClaudeMeter/Views/MenuBarView.swift
@@ -136,9 +136,7 @@ struct ProviderSection: View {
             if let usage = state.usage, !usage.limits.isEmpty {
                 ForEach(usage.limits, id: \.name) { limit in
                     UsageRow(
-                        title: limit.name,
-                        utilization: limit.utilization,
-                        resetTime: limit.resetTime,
+                        limit: limit,
                         accentColor: provider.accentColor
                     )
                 }
@@ -160,44 +158,36 @@ struct ProviderSection: View {
 // MARK: - Usage Row
 
 struct UsageRow: View {
-    let title: String
-    let utilization: Double
-    let resetTime: Date?
+    let limit: UsageLimit
     var accentColor: Color = .blue
-
-    var statusColor: Color {
-        switch utilization {
-        case ..<70: return .green
-        case 70..<90: return .yellow
-        default: return .red
-        }
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Text(title)
+                Text(limit.name)
                     .font(.system(size: 12))
                 Spacer()
-                Text("\(Int(utilization))%")
+                Text(limit.displayValue)
                     .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                    .foregroundColor(statusColor)
+                    .foregroundColor(limit.statusColor)
             }
 
-            // Progress bar
-            GeometryReader { geometry in
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.secondary.opacity(0.15))
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(statusColor)
-                        .frame(width: geometry.size.width * min(CGFloat(utilization) / 100, 1.0))
+            if !limit.isUnlimited {
+                // Progress bar (hidden for unlimited)
+                GeometryReader { geometry in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.secondary.opacity(0.15))
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(limit.statusColor)
+                            .frame(width: geometry.size.width * min(CGFloat(limit.utilization) / 100, 1.0))
+                    }
                 }
+                .frame(height: 6)
             }
-            .frame(height: 6)
 
             // Reset time
-            if let resetTime = resetTime {
+            if let resetTime = limit.resetTime {
                 Text("Resets \(formatTimeRemaining(resetTime))")
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary
- Users with unlimited spend on Claude Enterprise always saw **0%** because the API returns `utilization=0` when there's no cap
- Discovered that `extra_usage.used_credits` from the OAuth API is denominated in **cents USD** — dividing by 100 gives the exact dollar amount shown on claude.ai/settings/usage
- Now displays actual dollar spend (e.g., `$639`) with cost-based color thresholds instead of a meaningless percentage

## Changes
- **UsageProvider.swift**: Added `isUnlimited`, `creditsUsed`, `dollarCost` to `UsageLimit` model with dollar-based color thresholds (green <$200, orange <$1k, red <$2k, black $2k+)
- **ClaudeProvider.swift**: Detects unlimited plans (`monthly_limit` is nil or 0), formats names with dollar amounts, added `formatDollars` helper
- **MenuBarView.swift**: `UsageRow` takes `UsageLimit` directly, hides progress bar for unlimited plans, shows dollar amount instead of percentage
- **AIMeterApp.swift**: Status bar shows dollar amount with cost-based colors for unlimited plans
- **UsageManager.swift**: Cache model persists `isUnlimited` and `creditsUsed` fields (backward compatible)

## Test plan
- [ ] Verify unlimited Enterprise plan shows dollar spend (e.g., "$639") instead of "0%"
- [ ] Verify color thresholds: green <$200, orange <$1k, red <$2k, black $2k+
- [ ] Verify capped plans still show percentage and progress bar as before
- [ ] Verify cache roundtrip preserves new fields
- [ ] Verify old cache files without new fields load without errors

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)